### PR TITLE
non-prod/new-app-onboard-dev namespace

### DIFF
--- a/non-prod/new-app-onboard-dev-namespace.yaml
+++ b/non-prod/new-app-onboard-dev-namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/description: Demo 1
+  labels:
+    application: new-app-onboard
+    size: small
+    team: admin
+    environment: dev
+  name: new-app-onboard-


### PR DESCRIPTION
This is a request for the creation of the new-app-onboard-dev namespace in the non-prod from the group:default/admin team